### PR TITLE
Add EPEL/Fedora weekly edge builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository is an index for several projects providing *great prepackaged/pr
   - RPM
     - `dnf` | `yum` ([Fedora](https://getfedora.org))
       - [src.fedoraproject.org](https://src.fedoraproject.org/)
+      - [rezso/HDL](https://copr.fedorainfracloud.org/coprs/rezso/HDL) (CentOS and Fedora; x86_64, aarch64 and ppc64le)
       - [fedoraproject.org/wiki: Electronic Lab](https://fedoraproject.org/wiki/Electronic_Lab) a [lab/spin](https://labs.fedoraproject.org) not available anymore
     - `zypper` | `yast` ([OpenSUSE](https://www.opensuse.org/))
       - [build.opensuse.org | hardware:FPGA](https://build.opensuse.org/project/show/hardware:FPGA)


### PR DESCRIPTION
Hi !

This PR enlist native packages available by Fedora Copr build services.
Complete description can be found: https://copr.fedorainfracloud.org/coprs/rezso/HDL

Notable is the availability of packages for EPEL & Fedora x86_64, aarch64, ppc64le having latest upstream on weekly basis.

@umarcor 

Thank You !
~Cristian.